### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+
+# Django specific
+local_settings.py
+db.sqlite3
+media/
+staticfiles/
+logs/
+
+# Virtual environments
+venv/
+ENV/
+.env
+.env.*
+
+# IDEs
+.idea/
+*.iml
+
+# Misc
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add a project-wide `.gitignore` for common Python, Django, and IDE files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c2898d7808326b20f5cdbe10ede4f