### PR TITLE
Fix template indexing in correlation analysis

### DIFF
--- a/templates/visualization/analysis_correlation.html
+++ b/templates/visualization/analysis_correlation.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% load static %}
+{% load rlake_extras %}
 {% block title %}相関分析 - R-Lake{% endblock %}
 
 {% block content %}
@@ -65,7 +67,7 @@
                                 <tr>
                                     <th>{{ row_col }}</th>
                                     {% for col in analysis_result.columns_analyzed %}
-                                        <td>{{ analysis_result.correlation_matrix[row_col][col]|floatformat:2 }}</td>
+                                        <td>{{ analysis_result.correlation_matrix|get_item:row_col|get_item:col|floatformat:2 }}</td>
                                     {% endfor %}
                                 </tr>
                             {% endfor %}


### PR DESCRIPTION
## Summary
- update the correlation matrix table to use `get_item` filter for dynamic key access
- load `static` and `rlake_extras` in `analysis_correlation.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c559150f48326ab02ad7607a9b7c6