### PR TITLE
Fix chart preview overflow

### DIFF
--- a/templates/visualization/chart_create.html
+++ b/templates/visualization/chart_create.html
@@ -245,5 +245,10 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelector('form').addEventListener('change', previewChart);
 });
 </script>
+<style>
+#preview-container {
+    overflow-x: auto;
+}
+</style>
 {% endblock %}
 {% endblock %}

--- a/templates/visualization/chart_detail.html
+++ b/templates/visualization/chart_detail.html
@@ -337,6 +337,7 @@ document.addEventListener('keydown', function(e) {
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background-color: var(--bg-white);
+    overflow-x: auto;
 }
 
 /* フルスクリーン時のスタイル */

--- a/templates/visualization/chart_edit.html
+++ b/templates/visualization/chart_edit.html
@@ -341,6 +341,7 @@ document.getElementById('chartForm').addEventListener('change', function() {
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow-x: auto;
 }
 
 /* フォームスタイル調整 */


### PR DESCRIPTION
## Summary
- ensure Plotly charts fit within container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c5e56a38883269619df8d1ac5c523