### PR TITLE
Fix chart_detail redirect

### DIFF
--- a/visualization/views.py
+++ b/visualization/views.py
@@ -56,7 +56,8 @@ def chart_create(request):
             )
 
             messages.success(request, f'グラフ "{title}" が作成されました。')
-            return redirect("chart_detail", pk=chart.pk)
+            # Use namespaced URL to avoid reverse errors
+            return redirect("visualization:chart_detail", pk=chart.pk)
 
         except Exception as e:
             logger.error(f"グラフ作成エラー: {e}")


### PR DESCRIPTION
## Summary
- fix wrong redirect in chart creation view to use namespaced URL

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c644f6acc8326976477b1909df870