### PR TITLE
UI refinements for dataset and chart pages

### DIFF
--- a/templates/ingest/dataset_detail.html
+++ b/templates/ingest/dataset_detail.html
@@ -31,6 +31,11 @@
     overflow-y: auto;
 }
 
+.schema-preview {
+    max-height: 400px;
+    overflow-y: auto;
+}
+
 .quality-score {
     font-size: 3rem;
     font-weight: bold;
@@ -108,7 +113,7 @@
                         <i class="fas fa-car me-2"></i>車両メタデータ
                     </h5>
                 </div>
-                <div class="card-body">
+                <div class="card-body schema-preview">
                     <div class="row">
                         {% if dataset.vehicle_model %}
                         <div class="col-md-4">

--- a/templates/ingest/dataset_list.html
+++ b/templates/ingest/dataset_list.html
@@ -3,6 +3,10 @@
 
 {% block title %}データセット一覧 - R-Lake{% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+{% endblock %}
+
 {% block content %}
 <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center mb-4">
@@ -15,102 +19,34 @@
     </div>
 
     {% if datasets %}
-        <div class="row">
-            {% for dataset in datasets %}
-                <div class="col-md-6 col-lg-4 mb-4">
-                    <div class="card h-100">
-                        <div class="card-header d-flex justify-content-between align-items-center">
-                            <h5 class="card-title mb-0">{{ dataset.name }}</h5>
-                            {% if dataset.total_rows > 0 %}
-                                <span class="badge bg-success">{{ dataset.total_rows }} 行</span>
-                            {% else %}
-                                <span class="badge bg-warning">未処理</span>
-                            {% endif %}
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">{{ dataset.description|default:"説明なし"|truncatechars:100 }}</p>
-                            
-                            <div class="row text-center">
-                                <div class="col-6">
-                                    <div class="border-end">
-                                        <small class="text-muted d-block">作成者</small>
-                                        <strong>{{ dataset.created_by.username }}</strong>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <small class="text-muted d-block">作成日</small>
-                                    <strong>{{ dataset.created_at|date:"Y/m/d" }}</strong>
-                                </div>
-                            </div>
-                            
-                            {% if dataset.vehicle_model %}
-                                <hr>
-                                <div class="text-center">
-                                    <small class="text-muted d-block">車両モデル</small>
-                                    <strong>{{ dataset.vehicle_model }}</strong>
-                                </div>
-                            {% endif %}
-                        </div>
-                        <div class="card-footer">
-                            <div class="d-grid gap-2">
-                                <a href="{% url 'ingest:dataset_detail' dataset.pk %}" class="btn btn-outline-primary btn-sm">
-                                    <i class="fas fa-eye me-1"></i>詳細表示
-                                </a>
-                                <div class="btn-group" role="group">
-                                    <a href="{% url 'visualization:chart_create' %}?dataset={{ dataset.pk }}" 
-                                       class="btn btn-outline-success btn-sm">
-                                        <i class="fas fa-chart-line me-1"></i>グラフ作成
-                                    </a>
-                                    <a href="{% url 'visualization:analysis_correlation' dataset.pk %}" 
-                                       class="btn btn-outline-info btn-sm">
-                                        <i class="fas fa-analytics me-1"></i>分析
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
+        <div class="table-responsive">
+            <table id="datasetsTable" class="table table-striped table-bordered align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>名前</th>
+                        <th>行数</th>
+                        <th>作成者</th>
+                        <th>作成日</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for dataset in datasets %}
+                    <tr>
+                        <td>{{ dataset.name }}</td>
+                        <td>{{ dataset.total_rows }}</td>
+                        <td>{{ dataset.created_by.username }}</td>
+                        <td>{{ dataset.created_at|date:"Y/m/d" }}</td>
+                        <td class="text-nowrap">
+                            <a href="{% url 'ingest:dataset_detail' dataset.pk %}" class="btn btn-sm btn-outline-primary me-1">詳細</a>
+                            <a href="{% url 'visualization:chart_create' %}?dataset={{ dataset.pk }}" class="btn btn-sm btn-outline-success me-1">グラフ作成</a>
+                            <a href="{% url 'visualization:analysis_correlation' dataset.pk %}" class="btn btn-sm btn-outline-info">分析</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
-        
-        <!-- Pagination -->
-        {% if is_paginated %}
-            <nav aria-label="ページネーション">
-                <ul class="pagination justify-content-center">
-                    {% if page_obj.has_previous %}
-                        <li class="page-item">
-                            <a class="page-link" href="?page=1" aria-label="最初">
-                                <span aria-hidden="true">&laquo;&laquo;</span>
-                            </a>
-                        </li>
-                        <li class="page-item">
-                            <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="前">
-                                <span aria-hidden="true">&laquo;</span>
-                            </a>
-                        </li>
-                    {% endif %}
-                    
-                    <li class="page-item active">
-                        <span class="page-link">
-                            {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}
-                        </span>
-                    </li>
-                    
-                    {% if page_obj.has_next %}
-                        <li class="page-item">
-                            <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="次">
-                                <span aria-hidden="true">&raquo;</span>
-                            </a>
-                        </li>
-                        <li class="page-item">
-                            <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}" aria-label="最後">
-                                <span aria-hidden="true">&raquo;&raquo;</span>
-                            </a>
-                        </li>
-                    {% endif %}
-                </ul>
-            </nav>
-        {% endif %}
     {% else %}
         <div class="text-center py-5">
             <i class="fas fa-database fa-3x text-muted mb-3"></i>
@@ -124,10 +60,14 @@
 </div>
 
 {% block extra_js %}
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 <script>
-// データセット統計の更新
 document.addEventListener('DOMContentLoaded', function() {
-    // 将来的にリアルタイム更新機能を追加
+    $('#datasetsTable').DataTable({
+        language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/ja.json'
+        }
+    });
 });
 </script>
 {% endblock %}

--- a/templates/visualization/chart_create.html
+++ b/templates/visualization/chart_create.html
@@ -49,11 +49,15 @@
                             </select>
                         </div>
                         
+                        <div class="mb-3">
+                            <input type="text" id="columnFilter" class="form-control" placeholder="カラム名フィルター">
+                        </div>
+
                         <div class="row">
                             <div class="col-md-6">
                                 <div class="mb-3">
                                     <label for="x_axis_column" class="form-label">X軸カラム <span class="text-danger">*</span></label>
-                                    <select class="form-select" id="x_axis_column" name="x_axis_column" required>
+                                    <select class="form-select column-select" id="x_axis_column" name="x_axis_column" required>
                                         <option value="">まずデータセットを選択してください</option>
                                     </select>
                                 </div>
@@ -61,7 +65,7 @@
                             <div class="col-md-6">
                                 <div class="mb-3">
                                     <label for="y_axis_column" class="form-label">Y軸カラム</label>
-                                    <select class="form-select" id="y_axis_column" name="y_axis_column">
+                                    <select class="form-select column-select" id="y_axis_column" name="y_axis_column">
                                         <option value="">まずデータセットを選択してください</option>
                                     </select>
                                 </div>
@@ -72,7 +76,7 @@
                             <div class="col-md-4">
                                 <div class="mb-3">
                                     <label for="z_axis_column" class="form-label">Z軸カラム（3D用）</label>
-                                    <select class="form-select" id="z_axis_column" name="z_axis_column">
+                                    <select class="form-select column-select" id="z_axis_column" name="z_axis_column">
                                         <option value="">なし</option>
                                     </select>
                                 </div>
@@ -80,7 +84,7 @@
                             <div class="col-md-4">
                                 <div class="mb-3">
                                     <label for="color_column" class="form-label">色分けカラム</label>
-                                    <select class="form-select" id="color_column" name="color_column">
+                                    <select class="form-select column-select" id="color_column" name="color_column">
                                         <option value="">なし</option>
                                     </select>
                                 </div>
@@ -88,7 +92,7 @@
                             <div class="col-md-4">
                                 <div class="mb-3">
                                     <label for="size_column" class="form-label">サイズカラム</label>
-                                    <select class="form-select" id="size_column" name="size_column">
+                                    <select class="form-select column-select" id="size_column" name="size_column">
                                         <option value="">なし</option>
                                     </select>
                                 </div>
@@ -147,6 +151,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const zAxisSelect = document.getElementById('z_axis_column');
     const colorSelect = document.getElementById('color_column');
     const sizeSelect = document.getElementById('size_column');
+    const columnFilter = document.getElementById('columnFilter');
     const previewButton = document.getElementById('previewButton');
     const previewContainer = document.getElementById('preview-container');
 
@@ -167,6 +172,14 @@ document.addEventListener('DOMContentLoaded', function() {
             clearColumnSelects();
         }
     });
+
+    // URLのクエリからデータセットを事前選択
+    const params = new URLSearchParams(window.location.search);
+    const preselect = params.get('dataset');
+    if (preselect) {
+        datasetSelect.value = preselect;
+        datasetSelect.dispatchEvent(new Event('change'));
+    }
     
     function updateColumnSelects(columns) {
         const selects = [xAxisSelect, yAxisSelect, zAxisSelect, colorSelect, sizeSelect];
@@ -191,6 +204,9 @@ document.addEventListener('DOMContentLoaded', function() {
         zAxisSelect.children[0].textContent = "なし";
         colorSelect.children[0].textContent = "なし";
         sizeSelect.children[0].textContent = "なし";
+
+        // フィルタリング初期化
+        filterColumnOptions();
     }
     
     function clearColumnSelects() {
@@ -208,6 +224,15 @@ document.addEventListener('DOMContentLoaded', function() {
         colorSelect.children[0].textContent = "なし";
         sizeSelect.children[0].textContent = "なし";
     }
+
+    function filterColumnOptions() {
+        const filter = columnFilter.value.toLowerCase();
+        document.querySelectorAll('.column-select option').forEach(option => {
+            if (!option.value) return;
+            option.style.display = option.textContent.toLowerCase().includes(filter) ? '' : 'none';
+        });
+    }
+    columnFilter.addEventListener('input', filterColumnOptions);
 
     async function previewChart() {
         const form = document.querySelector('form');
@@ -247,7 +272,7 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 <style>
 #preview-container {
-    overflow: auto;
+    overflow: hidden;
 }
 </style>
 {% endblock %}

--- a/templates/visualization/chart_edit.html
+++ b/templates/visualization/chart_edit.html
@@ -59,34 +59,38 @@
                                 <option value="radar" {% if chart.chart_type == 'radar' %}selected{% endif %}>レーダーチャート</option>
                             </select>
                         </div>
-                        
+
+                        <div class="mb-3">
+                            <input type="text" id="columnFilter" class="form-control" placeholder="カラム名フィルター">
+                        </div>
+
                         <div class="mb-3">
                             <label for="x_axis_column" class="form-label">X軸</label>
-                            <select class="form-select" id="x_axis_column" name="x_axis_column">
+                            <select class="form-select column-select" id="x_axis_column" name="x_axis_column">
                                 <option value="">選択してください</option>
                                 <!-- データセットのカラムをJavaScriptで動的に追加 -->
                             </select>
                         </div>
-                        
+
                         <div class="mb-3">
                             <label for="y_axis_column" class="form-label">Y軸</label>
-                            <select class="form-select" id="y_axis_column" name="y_axis_column">
+                            <select class="form-select column-select" id="y_axis_column" name="y_axis_column">
                                 <option value="">選択してください</option>
                                 <!-- データセットのカラムをJavaScriptで動的に追加 -->
                             </select>
                         </div>
-                        
+
                         <div class="mb-3">
                             <label for="color_column" class="form-label">色分けカラム（オプション）</label>
-                            <select class="form-select" id="color_column" name="color_column">
+                            <select class="form-select column-select" id="color_column" name="color_column">
                                 <option value="">なし</option>
                                 <!-- データセットのカラムをJavaScriptで動的に追加 -->
                             </select>
                         </div>
-                        
+
                         <div class="mb-3">
                             <label for="size_column" class="form-label">サイズカラム（オプション）</label>
-                            <select class="form-select" id="size_column" name="size_column">
+                            <select class="form-select column-select" id="size_column" name="size_column">
                                 <option value="">なし</option>
                                 <!-- データセットのカラムをJavaScriptで動的に追加 -->
                             </select>
@@ -166,6 +170,9 @@ document.addEventListener('DOMContentLoaded', function() {
     loadCurrentChart();
 });
 
+// フィルタ入力要素
+const columnFilter = document.getElementById('columnFilter');
+
 // データセットのカラム情報を読み込み
 async function loadDatasetColumns() {
     try {
@@ -204,7 +211,19 @@ function populateColumnSelects() {
             select.appendChild(option);
         });
     });
+
+    filterColumnOptions();
 }
+
+function filterColumnOptions() {
+    const filter = columnFilter.value.toLowerCase();
+    document.querySelectorAll('.column-select option').forEach(option => {
+        if (!option.value) return;
+        option.style.display = option.textContent.toLowerCase().includes(filter) ? '' : 'none';
+    });
+}
+
+columnFilter.addEventListener('input', filterColumnOptions);
 
 // 現在のグラフ設定を読み込み
 function loadCurrentChart() {
@@ -341,7 +360,7 @@ document.getElementById('chartForm').addEventListener('change', function() {
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow-x: auto;
+    overflow: hidden;
 }
 
 /* フォームスタイル調整 */


### PR DESCRIPTION
## Summary
- use DataTables on dataset list for better browsing
- match dataset schema scroll area height to data preview
- add column filter on chart create/edit forms
- auto-select dataset from query on chart create
- adjust preview container styles to avoid scrolling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688c6bfd8a8c8326b01f9881cb5eccf1