### PR TITLE
Fix DataTables reinitialisation

### DIFF
--- a/templates/ingest/dataset_list.html
+++ b/templates/ingest/dataset_list.html
@@ -63,7 +63,11 @@
 <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    $('#datasetsTable').DataTable({
+    var table = $('#datasetsTable');
+    if ($.fn.dataTable.isDataTable(table)) {
+        table.DataTable().clear().destroy();
+    }
+    table.DataTable({
         language: {
             url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/ja.json'
         }


### PR DESCRIPTION
## Summary
- prevent reinitialisation errors on the dataset list page

## Testing
- `python test_auth.py` *(fails: ModuleNotFoundError)*
- `python test_r_lake.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688c716007c88326af071a93c4fed807