### PR TITLE
Fix chart editor preview initialization

### DIFF
--- a/templates/visualization/chart_edit.html
+++ b/templates/visualization/chart_edit.html
@@ -165,8 +165,9 @@ const datasetId = {{ chart.dataset.pk }};
 let datasetColumns = [];
 
 // ページ読み込み時の初期化
-document.addEventListener('DOMContentLoaded', function() {
-    loadDatasetColumns();
+document.addEventListener('DOMContentLoaded', async function() {
+    // データセットのカラムを取得してから現在の設定を反映する
+    await loadDatasetColumns();
     loadCurrentChart();
 });
 
@@ -357,9 +358,6 @@ document.getElementById('chartForm').addEventListener('change', function() {
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background-color: var(--bg-white);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- ensure dataset columns load before applying current settings in chart edit page
- remove flex styling from preview container to fix misaligned graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894104758b883269a447a6d4d369ce3