### PR TITLE
Fix chart data API to return traces for rendering

### DIFF
--- a/visualization/tests.py
+++ b/visualization/tests.py
@@ -1,3 +1,39 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
 
-# Create your tests here.
+from ingest.models import Dataset, DataRecord
+from visualization.models import Chart
+
+
+class ChartDataAPITests(TestCase):
+    """Tests for the chart data API."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username="test", password="pass")
+        self.client = Client()
+        self.client.login(username="test", password="pass")
+
+        # Create a minimal dataset with a single record
+        self.dataset = Dataset.objects.create(name="ds", created_by=self.user)
+        DataRecord.objects.create(
+            dataset=self.dataset,
+            row_number=1,
+            data={"x": 1, "y": 2},
+            data_hash="hash1",
+        )
+
+        self.chart = Chart.objects.create(
+            title="test chart",
+            chart_type="line",
+            dataset=self.dataset,
+            created_by=self.user,
+            x_axis_column="x",
+            y_axis_column="y",
+            chart_config={},
+        )
+
+    def test_chart_data_api_returns_traces(self) -> None:
+        response = self.client.get(f"/visualization/api/charts/{self.chart.id}/data/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("traces", data)

--- a/visualization/views.py
+++ b/visualization/views.py
@@ -175,11 +175,9 @@ def chart_data_api(request, chart_id):
         fig, result = generator.generate_chart(chart)
 
         if result["success"]:
-            # Plotly図をJSON形式で返す
-            chart_json = fig.to_json()
-            return JsonResponse(
-                {"chart_data": json.loads(chart_json), "result": result}
-            )
+            # Plotly図のトレースをJSON形式で返す
+            chart_json = fig.to_plotly_json()
+            return JsonResponse({"traces": chart_json["data"], "result": result})
         else:
             return JsonResponse(
                 {"error": result.get("error", "不明なエラー")}, status=500


### PR DESCRIPTION
## Summary
- Return Plotly traces from `chart_data_api` so chart detail page can render charts
- Add regression test covering API response shape

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689412798c3c8326b9702f6639429586