### PR TITLE
Handle missing dataset in chart preview

### DIFF
--- a/visualization/tests.py
+++ b/visualization/tests.py
@@ -37,3 +37,36 @@ class ChartDataAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("traces", data)
+
+
+class ChartPreviewAPITests(TestCase):
+    """Tests for the chart preview API."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username="preview", password="pass")
+        self.client = Client()
+        self.client.login(username="preview", password="pass")
+
+        self.dataset = Dataset.objects.create(name="ds", created_by=self.user)
+        DataRecord.objects.create(
+            dataset=self.dataset,
+            row_number=1,
+            data={"x": 1, "y": 2},
+            data_hash="hash2",
+        )
+
+    def test_preview_new_returns_traces(self) -> None:
+        response = self.client.post(
+            "/visualization/api/charts/preview/",
+            {
+                "dataset": self.dataset.id,
+                "title": "tmp",
+                "chart_type": "line",
+                "x_axis_column": "x",
+                "y_axis_column": "y",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["success"])
+        self.assertIn("traces", data)

--- a/visualization/views.py
+++ b/visualization/views.py
@@ -447,7 +447,12 @@ class ChartViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["post"], url_path="preview")
     def preview_new(self, request):  # type: ignore[override]
         """新規作成時のプレビュー生成"""
-        dataset_id = request.data.get("dataset")
+        dataset_id = request.data.get("dataset") or request.data.get("dataset_id")
+        if not dataset_id:
+            return Response(
+                {"success": False, "error": "データセットが指定されていません"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             dataset = Dataset.objects.get(id=dataset_id, is_active=True)
         except Dataset.DoesNotExist:


### PR DESCRIPTION
## Summary
- validate dataset id in chart preview API and support `dataset_id` param
- add regression test ensuring preview API returns traces when dataset provided

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6894207b0f108326bb428c272df5c1b0