### PR TITLE
Load Plotly.js from CDN

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,6 +37,9 @@
         }
     </style>
     
+    <!-- Plotly.js -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+
     <!-- Plotly.js fallback -->
     <script>
         // Plotly fallback implementation


### PR DESCRIPTION
## Summary
- Ensure Plotly charts render by loading Plotly.js from a CDN in the base template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c2fba8b88326b15d27b6d7b0992a